### PR TITLE
Issue#71 in memory file serialization testing

### DIFF
--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/ReceiverAsyncTask.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/ReceiverAsyncTask.java
@@ -99,32 +99,29 @@ public class ReceiverAsyncTask extends AsyncTask
                             .insertFileMessage(macAddress, new Date(), false, imf, this.context);
                 }
             }
-            return null;
         }
         catch (IOException e)
         {
             Log.e(LOG_TAG, "Error receiving data: " + e.getMessage());
-            return null;
-        }
-    }
-
-    public static InMemoryFile parseInMemoryFileFromInputStream(InputStream inputStream)
-    {
-        try
-        {
-            ObjectInputStream ois = new ObjectInputStream(inputStream);
-            return (InMemoryFile) ois.readObject();
         }
         catch (ClassNotFoundException e)
         {
-            Log.d(LOG_TAG,
-                    "Could not convert input stream to InMemoryFile.");
-            Log.e(LOG_TAG, "ClassNotFoundException: " + e.getMessage());
-        }
-        catch (IOException e)
-        {
-            Log.e(LOG_TAG, "Error creating ObjectInputStream: " + e.getMessage());
+            Log.e(LOG_TAG, "InputStream did not contain InMemoryFile. " + e.getMessage());
         }
         return null;
+    }
+
+    /**
+     * Converts an inputStream into an InMemoryFile object.
+     * @param inputStream An InputStream which contains a serialized InMemoryFile object.
+     * @return an InMemoryFile which came from the parameter InputStream.
+     * @throws IOException if the parameter InputStream could not be opened.
+     * @throws ClassNotFoundException if the InputStream does not contain an InMemoryFile.
+     */
+    public static InMemoryFile parseInMemoryFileFromInputStream(InputStream inputStream)
+        throws IOException, ClassNotFoundException
+    {
+        ObjectInputStream ois = new ObjectInputStream(inputStream);
+        return (InMemoryFile) ois.readObject();
     }
 }

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/ReceiverAsyncTask.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/ReceiverAsyncTask.java
@@ -113,15 +113,21 @@ public class ReceiverAsyncTask extends AsyncTask
 
     /**
      * Converts an inputStream into an InMemoryFile object.
-     * @param inputStream An InputStream which contains a serialized InMemoryFile object.
+     *
+     * @param inputStream
+     *         An InputStream which contains a serialized InMemoryFile object.
      * @return an InMemoryFile which came from the parameter InputStream.
-     * @throws IOException if the parameter InputStream could not be opened.
-     * @throws ClassNotFoundException if the InputStream does not contain an InMemoryFile.
+     * @throws IOException
+     *         if the parameter InputStream could not be opened.
+     * @throws ClassNotFoundException
+     *         if the InputStream does not contain an InMemoryFile.
      */
     public static InMemoryFile parseInMemoryFileFromInputStream(InputStream inputStream)
-        throws IOException, ClassNotFoundException
+            throws IOException, ClassNotFoundException
     {
         ObjectInputStream ois = new ObjectInputStream(inputStream);
-        return (InMemoryFile) ois.readObject();
+        InMemoryFile imf = (InMemoryFile) ois.readObject();
+        ois.close();
+        return imf;
     }
 }

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/SendDataService.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/SendDataService.java
@@ -249,25 +249,15 @@ public final class SendDataService extends IntentService
      *         an InMemoryFile that we wish to serialize.
      * @return an InputStream with a serialized InMemoryFile,
      * or null if an error occurred.
+     * @throws IOException thrown when there is an issue opening InputStream
      */
     public static InputStream serializeInMemoryFile(InMemoryFile imf)
+        throws IOException
     {
-        try
-        {
-            InputStream inputStream = new FileInputStream("imf.ser");
-            inputStream = new BufferedInputStream(inputStream);
-            inputStream = new ObjectInputStream(inputStream);
-            return inputStream;
-        }
-        catch (FileNotFoundException e)
-        {
-            Log.e(LOG_TAG, "404 Error: " + e.getMessage());
-        }
-        catch (IOException e)
-        {
-            Log.e(LOG_TAG, "Error creating ObjectInputStream: " + e.getMessage());
-        }
-        return null;
+        InputStream inputStream = new FileInputStream("imf.ser");
+        inputStream = new BufferedInputStream(inputStream);
+        inputStream = new ObjectInputStream(inputStream);
+        return inputStream;
     }
 
     /**
@@ -277,25 +267,15 @@ public final class SendDataService extends IntentService
      *         an InetAddress that we wish to serialize
      * @return an InputStream with a serialized InetAddress,
      * or null if an error occurred.
+     * @throws IOException thrown when there is an issue opening InputStream
      */
     public static InputStream serializeINetAddress(InetAddress address)
+        throws IOException
     {
-        try
-        {
-            InputStream inputStream = new FileInputStream("address.ser");
-            inputStream = new BufferedInputStream(inputStream);
-            inputStream = new ObjectInputStream(inputStream);
-            return inputStream;
-        }
-        catch (FileNotFoundException e)
-        {
-            Log.e(LOG_TAG, "404 Error: " + e.getMessage());
-        }
-        catch (IOException e)
-        {
-            Log.e(LOG_TAG, "Error creating ObjectInputStream: " + e.getMessage());
-        }
-        return null;
+        InputStream inputStream = new FileInputStream("address.ser");
+        inputStream = new BufferedInputStream(inputStream);
+        inputStream = new ObjectInputStream(inputStream);
+        return inputStream;
     }
 
     /**

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/SendDataService.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/SendDataService.java
@@ -8,11 +8,15 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -161,6 +165,7 @@ public final class SendDataService extends IntentService
             if (inputStream != null)
             {
                 transferStreams(inputStream, outputStream);
+                inputStream.close();
             }
             Log.d(LOG_TAG, "Client: Data Written");
         }
@@ -217,6 +222,7 @@ public final class SendDataService extends IntentService
             if (inputStream != null)
             {
                 transferStreams(inputStream, outputStream);
+                inputStream.close();
             }
             Log.d(LOG_TAG, "Client: Data written for host update");
 
@@ -249,15 +255,18 @@ public final class SendDataService extends IntentService
      *         an InMemoryFile that we wish to serialize.
      * @return an InputStream with a serialized InMemoryFile,
      * or null if an error occurred.
-     * @throws IOException thrown when there is an issue opening InputStream
+     * @throws IOException
+     *         thrown when there is an issue opening InputStream
      */
     public static InputStream serializeInMemoryFile(InMemoryFile imf)
-        throws IOException
+            throws IOException
     {
-        InputStream inputStream = new FileInputStream("imf.ser");
-        inputStream = new BufferedInputStream(inputStream);
-        inputStream = new ObjectInputStream(inputStream);
-        return inputStream;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(imf);
+        oos.flush();
+        oos.close();
+        return new ByteArrayInputStream(baos.toByteArray());
     }
 
     /**
@@ -267,15 +276,18 @@ public final class SendDataService extends IntentService
      *         an InetAddress that we wish to serialize
      * @return an InputStream with a serialized InetAddress,
      * or null if an error occurred.
-     * @throws IOException thrown when there is an issue opening InputStream
+     * @throws IOException
+     *         thrown when there is an issue opening InputStream
      */
     public static InputStream serializeINetAddress(InetAddress address)
-        throws IOException
+            throws IOException
     {
-        InputStream inputStream = new FileInputStream("address.ser");
-        inputStream = new BufferedInputStream(inputStream);
-        inputStream = new ObjectInputStream(inputStream);
-        return inputStream;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(address);
+        oos.flush();
+        oos.close();
+        return new ByteArrayInputStream(baos.toByteArray());
     }
 
     /**

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/SendDataService.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/SendDataService.java
@@ -162,11 +162,8 @@ public final class SendDataService extends IntentService
             InputStream inputStream = serializeInMemoryFile(IMF);
 
             // this is where the data is sent
-            if (inputStream != null)
-            {
-                transferStreams(inputStream, outputStream);
-                inputStream.close();
-            }
+            transferStreams(inputStream, outputStream);
+            inputStream.close();
             Log.d(LOG_TAG, "Client: Data Written");
         }
         catch (IOException e)
@@ -219,11 +216,8 @@ public final class SendDataService extends IntentService
             OutputStream outputStream = socket.getOutputStream();
             InputStream inputStream = serializeINetAddress(LOCALHOST);
             // this is where the data is sent
-            if (inputStream != null)
-            {
-                transferStreams(inputStream, outputStream);
-                inputStream.close();
-            }
+            transferStreams(inputStream, outputStream);
+            inputStream.close();
             Log.d(LOG_TAG, "Client: Data written for host update");
 
         }

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/UpdaterAsyncTask.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/UpdaterAsyncTask.java
@@ -98,13 +98,17 @@ public class UpdaterAsyncTask extends AsyncTask
      *         an InputStream that must contain an InetAddress
      * @return an InetAddress that was serialized in the InputStream,
      * or null if an error occurred during parsing.
-     * @throws IOException if the parameter InputStream could not be opened.
-     * @throws ClassNotFoundException if the InputStream does not contain an InetAddress.
+     * @throws IOException
+     *         if the parameter InputStream could not be opened.
+     * @throws ClassNotFoundException
+     *         if the InputStream does not contain an InetAddress.
      */
     public static InetAddress parseInetAddressFromInputStream(InputStream inputStream)
-    throws IOException, ClassNotFoundException
+            throws IOException, ClassNotFoundException
     {
         ObjectInputStream ois = new ObjectInputStream(inputStream);
-        return (InetAddress) ois.readObject();
+        InetAddress address = (InetAddress) ois.readObject();
+        ois.close();
+        return address;
     }
 }

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/UpdaterAsyncTask.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/UpdaterAsyncTask.java
@@ -84,6 +84,10 @@ public class UpdaterAsyncTask extends AsyncTask
         {
             Log.e(LOG_TAG, "Error receiving data: " + e.getMessage());
         }
+        catch (ClassNotFoundException e)
+        {
+            Log.e(LOG_TAG, "InputStream does not contain an InetAddress" + e.getMessage());
+        }
         return null;
     }
 
@@ -94,22 +98,13 @@ public class UpdaterAsyncTask extends AsyncTask
      *         an InputStream that must contain an InetAddress
      * @return an InetAddress that was serialized in the InputStream,
      * or null if an error occurred during parsing.
+     * @throws IOException if the parameter InputStream could not be opened.
+     * @throws ClassNotFoundException if the InputStream does not contain an InetAddress.
      */
     public static InetAddress parseInetAddressFromInputStream(InputStream inputStream)
+    throws IOException, ClassNotFoundException
     {
-        try
-        {
-            ObjectInputStream ois = new ObjectInputStream(inputStream);
-            return (InetAddress) ois.readObject();
-        }
-        catch (IOException e)
-        {
-            Log.e(LOG_TAG, "Error creating ObjectInputStream: " + e.getMessage());
-        }
-        catch (ClassNotFoundException e)
-        {
-            Log.e(LOG_TAG, "Error parsing InetAddress from ObjectInputStream: " + e.getMessage());
-        }
-        return null;
+        ObjectInputStream ois = new ObjectInputStream(inputStream);
+        return (InetAddress) ois.readObject();
     }
 }

--- a/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/UpdaterAsyncTask.java
+++ b/app/src/main/java/edu/uwstout/p2pchat/FileTransfer/UpdaterAsyncTask.java
@@ -20,6 +20,7 @@ import edu.uwstout.p2pchat.WifiDirect;
  * INetAddress objects which are sent by clients.
  * The INetAddress informs the server / host on
  * how to communicate with their clients.
+ *
  * @author VanderHoevenEvan (Evan Vander Hoeven)
  */
 public class UpdaterAsyncTask extends AsyncTask
@@ -40,7 +41,9 @@ public class UpdaterAsyncTask extends AsyncTask
 
     /**
      * Non-Default Constructor
-     * @param c Application context
+     *
+     * @param c
+     *         Application context
      */
     public UpdaterAsyncTask(final Context c)
     {
@@ -49,7 +52,9 @@ public class UpdaterAsyncTask extends AsyncTask
 
     /**
      * Listens for incoming messages in the background.
-     * @param objects Required by the superclass, these are unnecessary.
+     *
+     * @param objects
+     *         Required by the superclass, these are unnecessary.
      * @return An object. Currently null.
      */
     @Override
@@ -64,30 +69,47 @@ public class UpdaterAsyncTask extends AsyncTask
             Socket client = serverSocket.accept();
             // When we pass that line, we have accepted a connection.
             Log.i(LOG_TAG, "Updater: Connection Established");
-            InputStream inputStream = client.getInputStream();
-            ObjectInputStream ois = new ObjectInputStream(inputStream);
             // get the INetAddress object from the InputStream
-            InetAddress clientLocalHost;
-            try
-            {
-                clientLocalHost = (InetAddress) ois.readObject();
-            }
-            catch (ClassNotFoundException e)
-            {
-                Log.d(LOG_TAG, "Could not convert input stream to InetAddress");
-                Log.e(LOG_TAG, "ClassNotFoundException: " + e.getMessage());
-                return null;
-            }
+            InetAddress clientLocalHost = parseInetAddressFromInputStream(
+                    client.getInputStream());
             // Update the singleton with the new Client information.
-            Log.i(LOG_TAG,
-                    "Client information received. " + clientLocalHost.getCanonicalHostName());
-            WifiDirect.getInstance(this.context).setClient(clientLocalHost);
-            return null;
+            if (clientLocalHost != null)
+            {
+                Log.i(LOG_TAG,
+                        "Client information received. " + clientLocalHost.getCanonicalHostName());
+                WifiDirect.getInstance(this.context).setClient(clientLocalHost);
+            }
         }
         catch (IOException e)
         {
             Log.e(LOG_TAG, "Error receiving data: " + e.getMessage());
-            return null;
         }
+        return null;
+    }
+
+    /**
+     * Converts an input stream into an InetAddress
+     *
+     * @param inputStream
+     *         an InputStream that must contain an InetAddress
+     * @return an InetAddress that was serialized in the InputStream,
+     * or null if an error occurred during parsing.
+     */
+    public static InetAddress parseInetAddressFromInputStream(InputStream inputStream)
+    {
+        try
+        {
+            ObjectInputStream ois = new ObjectInputStream(inputStream);
+            return (InetAddress) ois.readObject();
+        }
+        catch (IOException e)
+        {
+            Log.e(LOG_TAG, "Error creating ObjectInputStream: " + e.getMessage());
+        }
+        catch (ClassNotFoundException e)
+        {
+            Log.e(LOG_TAG, "Error parsing InetAddress from ObjectInputStream: " + e.getMessage());
+        }
+        return null;
     }
 }

--- a/app/src/test/java/edu/uwstout/p2pchat/SerializationTest.java
+++ b/app/src/test/java/edu/uwstout/p2pchat/SerializationTest.java
@@ -29,46 +29,79 @@ public class SerializationTest
     {
         // Create the InMemoryFile we want to serialize
         InMemoryFile imf = new InMemoryFile("Hello World!");
+        InputStream inputStream = null;
+        // If the Bad Message isn't overwritten by deserialization, we assert false.
+        InMemoryFile imfRetrieved = new InMemoryFile("Bad Message!");
         try
         {
             // serialize it.
-            InputStream inputStream = SendDataService.serializeInMemoryFile(imf);
+            inputStream = SendDataService.serializeInMemoryFile(imf);
             assertThat(inputStream).isNotNull();
-            // deserialize it.
-            InMemoryFile imfRetrieved = ReceiverAsyncTask.parseInMemoryFileFromInputStream(inputStream);
-            assertThat(imfRetrieved).isNotNull();
-            // Check that the contents were preserved.
-            assertThat(imfRetrieved.getMimeType()).isEqualTo(imf.getMimeType());
-            assertThat(imfRetrieved.getTextMessage()).isEqualTo(imf.getTextMessage());
         }
         catch (Exception e)
         {
             assert(false); // exceptions are bad and should feel bad.
         }
+        try
+        {
+            // deserialize it.
+            imfRetrieved = ReceiverAsyncTask.parseInMemoryFileFromInputStream(inputStream);
+            assertThat(imfRetrieved).isNotNull();
+        }
+        catch (Exception e)
+        {
+            assert(false); // separate try/catch tells us where the error is occuring.
+        }
+        // Check that the contents were preserved.
+        assertThat(imfRetrieved.getMimeType()).isEqualTo(imf.getMimeType());
+        assertThat(imfRetrieved.getTextMessage()).isEqualTo(imf.getTextMessage());
     }
 
+    /**
+     * Checks that we can serialize and deserialize an
+     * InetAddress without data loss.
+     */
     @Test
     public void INetAddressSerialization()
     {
+        // Create the INetAddress we want to serialize.
+        byte[] ipAddr = new byte[]{127, 0, 0, 1};
+        InetAddress address = null;
+        InputStream inputStream = null;
+        InetAddress receivedAddress = null;
         try
         {
-            // Create the INetAddress we want to serialize.
-            byte[] ipAddr = new byte[]{127, 0, 0, 1};
-            InetAddress address = InetAddress.getByAddress(ipAddr);
+            address = InetAddress.getByAddress(ipAddr);
+        }
+        catch (UnknownHostException e)
+        {
+            // This isn't a good error, because the test fails
+            // before we get to our own code.
+            assert(false);
+        }
+        try
+        {
             // serialize it.
-            InputStream inputStream = SendDataService.serializeINetAddress(address);
+            inputStream = SendDataService.serializeINetAddress(address);
             assertThat(inputStream).isNotNull();
-            // deserialize it.
-            InetAddress receivedAddress =
-                    UpdaterAsyncTask.parseInetAddressFromInputStream(inputStream);
-            assertThat(receivedAddress).isNotNull();
-            // Check that the contents were preserved.
-            assertThat(receivedAddress.getCanonicalHostName())
-                    .isEqualTo(address.getCanonicalHostName());
         }
         catch (Exception e)
         {
             assert(false); // exceptions are inherently bad in testing
         }
+
+        try
+        {
+            // deserialize it.
+            receivedAddress = UpdaterAsyncTask.parseInetAddressFromInputStream(inputStream);
+            assertThat(receivedAddress).isNotNull();
+        }
+        catch (Exception e)
+        {
+            assert(false);
+        }
+        // Check that the contents were preserved.
+        assertThat(receivedAddress.getCanonicalHostName())
+                .isEqualTo(address.getCanonicalHostName());
     }
 }

--- a/app/src/test/java/edu/uwstout/p2pchat/SerializationTest.java
+++ b/app/src/test/java/edu/uwstout/p2pchat/SerializationTest.java
@@ -29,15 +29,22 @@ public class SerializationTest
     {
         // Create the InMemoryFile we want to serialize
         InMemoryFile imf = new InMemoryFile("Hello World!");
-        // serialize it.
-        InputStream inputStream = SendDataService.serializeInMemoryFile(imf);
-        assertThat(inputStream).isNotNull();
-        // deserialize it.
-        InMemoryFile imfRetrieved = ReceiverAsyncTask.parseInMemoryFileFromInputStream(inputStream);
-        assertThat(imfRetrieved).isNotNull();
-        // Check that the contents were preserved.
-        assertThat(imfRetrieved.getMimeType()).isEqualTo(imf.getMimeType());
-        assertThat(imfRetrieved.getTextMessage()).isEqualTo(imf.getTextMessage());
+        try
+        {
+            // serialize it.
+            InputStream inputStream = SendDataService.serializeInMemoryFile(imf);
+            assertThat(inputStream).isNotNull();
+            // deserialize it.
+            InMemoryFile imfRetrieved = ReceiverAsyncTask.parseInMemoryFileFromInputStream(inputStream);
+            assertThat(imfRetrieved).isNotNull();
+            // Check that the contents were preserved.
+            assertThat(imfRetrieved.getMimeType()).isEqualTo(imf.getMimeType());
+            assertThat(imfRetrieved.getTextMessage()).isEqualTo(imf.getTextMessage());
+        }
+        catch (Exception e)
+        {
+            assert(false); // exceptions are bad and should feel bad.
+        }
     }
 
     @Test
@@ -52,16 +59,16 @@ public class SerializationTest
             InputStream inputStream = SendDataService.serializeINetAddress(address);
             assertThat(inputStream).isNotNull();
             // deserialize it.
-            InetAddress recievedAddress =
+            InetAddress receivedAddress =
                     UpdaterAsyncTask.parseInetAddressFromInputStream(inputStream);
-            assertThat(recievedAddress).isNotNull();
+            assertThat(receivedAddress).isNotNull();
             // Check that the contents were preserved.
-            assertThat(recievedAddress.getCanonicalHostName())
+            assertThat(receivedAddress.getCanonicalHostName())
                     .isEqualTo(address.getCanonicalHostName());
         }
-        catch (UnknownHostException e)
+        catch (Exception e)
         {
-            assert(false);
+            assert(false); // exceptions are inherently bad in testing
         }
     }
 }

--- a/app/src/test/java/edu/uwstout/p2pchat/SerializationTest.java
+++ b/app/src/test/java/edu/uwstout/p2pchat/SerializationTest.java
@@ -1,0 +1,67 @@
+package edu.uwstout.p2pchat;
+
+import static com.google.common.truth.Truth.*;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import edu.uwstout.p2pchat.FileTransfer.ReceiverAsyncTask;
+import edu.uwstout.p2pchat.FileTransfer.SendDataService;
+import edu.uwstout.p2pchat.FileTransfer.UpdaterAsyncTask;
+
+/**
+ * Tests the serialization and deserialization
+ * the InMemoryFile and InetAddress classes.
+ * This functionality is essential for data
+ * transfer and must be solid.
+ */
+public class SerializationTest
+{
+    /**
+     * Checks that we can serialize and deserialize an
+     * InMemoryFile without data loss.
+     */
+    @Test
+    public void InMemoryFileSerialization()
+    {
+        // Create the InMemoryFile we want to serialize
+        InMemoryFile imf = new InMemoryFile("Hello World!");
+        // serialize it.
+        InputStream inputStream = SendDataService.serializeInMemoryFile(imf);
+        assertThat(inputStream).isNotNull();
+        // deserialize it.
+        InMemoryFile imfRetrieved = ReceiverAsyncTask.parseInMemoryFileFromInputStream(inputStream);
+        assertThat(imfRetrieved).isNotNull();
+        // Check that the contents were preserved.
+        assertThat(imfRetrieved.getMimeType()).isEqualTo(imf.getMimeType());
+        assertThat(imfRetrieved.getTextMessage()).isEqualTo(imf.getTextMessage());
+    }
+
+    @Test
+    public void INetAddressSerialization()
+    {
+        try
+        {
+            // Create the INetAddress we want to serialize.
+            byte[] ipAddr = new byte[]{127, 0, 0, 1};
+            InetAddress address = InetAddress.getByAddress(ipAddr);
+            // serialize it.
+            InputStream inputStream = SendDataService.serializeINetAddress(address);
+            assertThat(inputStream).isNotNull();
+            // deserialize it.
+            InetAddress recievedAddress =
+                    UpdaterAsyncTask.parseInetAddressFromInputStream(inputStream);
+            assertThat(recievedAddress).isNotNull();
+            // Check that the contents were preserved.
+            assertThat(recievedAddress.getCanonicalHostName())
+                    .isEqualTo(address.getCanonicalHostName());
+        }
+        catch (UnknownHostException e)
+        {
+            assert(false);
+        }
+    }
+}


### PR DESCRIPTION
closes #71 
I did have to modify the code that I was testing for two reasons:
- The unit tests crash if you have logging statements in there, so I had the methods throw the errors directly instead.
- The serialization code was actually wrong, so they were refactored to work as intended.

If I am wrong about the above two statements, Circle CI will prevent the branch from merging anyways.